### PR TITLE
Added option to not sort figures by increasing R0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,12 @@
 
 * New `hom_plot_critical_times_by_location()` plots critical time by location.
 
+* In `hom_plot_r0_by_location()`, also takes optional `sort` variable.
+
+* In `hom_plot_zeta_by_location()`, also takes optional `sort` variable.
+
+* In `hom_plot_incidence_by_location`, also takes optional `sort` variable.
+
 
 # cr0eso 0.0.0.9001
 

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -83,9 +83,10 @@ hom_extract_posterior_draws <- function(posts,
 #' Plot r0 by location as extracted from hierarchical outbreak model.
 #' @description If extracted_posts is NULL then posts object is used to first extract the R0
 #' and incidence draws from posterior (note this will take longer)
-#' @note Naming convention throughout is snake case with prefix "hom_" to denote Hierarcical Outbreak Model
+#' @note Naming convention throughout is snake case with prefix "hom_" to denote Hierarchical Outbreak Model
 #' @param extracted_posts object returned by hom_extract_posterior_draws
 #' @param posts Object after calling extract of stan model object of hierarchical model
+#' @param sort TRUE/FALSE. If TRUE (default), locations will be ordered by mean R0
 #' @importFrom stats quantile
 #' @return list containing:
 #'  * plot - ggplot object
@@ -100,7 +101,7 @@ hom_extract_posterior_draws <- function(posts,
 #'  show(result$plot)
 #'  }
 #' @export
-hom_plot_r0_by_location <- function(extracted_posts=NULL,posts=NULL){
+hom_plot_r0_by_location <- function(extracted_posts=NULL,posts=NULL,sort=TRUE){
 
   r0 <- type <- ob_code <- location <- NULL
 
@@ -119,7 +120,7 @@ hom_plot_r0_by_location <- function(extracted_posts=NULL,posts=NULL){
   loc_ordering <- r0s %>%
     dplyr::group_by(location) %>%
     dplyr::summarise(mean=mean(r0)) %>%
-    dplyr::arrange(mean) %>%
+    dplyr::arrange(if(sort==TRUE){mean}else{location}) %>%
     dplyr::pull(location)
 
   plot_data <- r0s %>%
@@ -169,6 +170,7 @@ hom_plot_r0_by_location <- function(extracted_posts=NULL,posts=NULL){
 #' @note Naming convention throughout is snake case with prefix "hom_" to denote Hierarcical Outbreak Model
 #' @param extracted_posts object returned by hom_extract_posterior_draws
 #' @param posts Object after calling extract of stan model object of hierarchical model
+#' @param sort TRUE/FALSE. If TRUE (default), locations will be ordered by mean R0
 #' @importFrom stats quantile
 #' @importFrom magrittr %>%
 #' @return list containing:
@@ -184,7 +186,7 @@ hom_plot_r0_by_location <- function(extracted_posts=NULL,posts=NULL){
 #'  show(result$plot)
 #'  }
 #' @export
-hom_plot_zeta_by_location <- function(extracted_posts=NULL,posts=NULL){
+hom_plot_zeta_by_location <- function(extracted_posts=NULL,posts=NULL,sort=TRUE){
 
   location <- zeta <- type <- ob_code <- NULL
 
@@ -202,7 +204,7 @@ hom_plot_zeta_by_location <- function(extracted_posts=NULL,posts=NULL){
   loc_ordering <- zetas %>%
     dplyr::group_by(location) %>%
     dplyr::summarise(mean=mean(zeta)) %>%
-    dplyr::arrange(mean) %>%
+    dplyr::arrange(if(sort==TRUE){mean}else{location}) %>%
     dplyr::pull(location)
 
   plot_data <- zetas %>%
@@ -313,6 +315,7 @@ hom_plot_critical_times_by_location <- function(posts,
 #' @param end_time time in days to plot up until
 #' @param location_labels tibble with columns `site` and `location`. Will be used to
 #'   relabel numeric location to values in `site` column
+#' @param sort TRUE/FALSE. If TRUE (default), locations will be ordered by mean R0
 #' @importFrom magrittr %>%
 #' @return list containing:
 #'  * plot - ggplot object
@@ -331,7 +334,7 @@ hom_plot_critical_times_by_location <- function(posts,
 #' @export
 hom_plot_incidence_by_location <- function(extracted_posts=NULL,posts=NULL,
                                     outbreak_cases=NULL, end_time=60,
-                                    location_labels = NULL){
+                                    location_labels = NULL,sort=TRUE){
 
   r0 <- time <- location <- label <- lc <- uc <- liqr <- uiqr <- m <- data_incidence <- NULL
 
@@ -349,7 +352,7 @@ hom_plot_incidence_by_location <- function(extracted_posts=NULL,posts=NULL,
   loc_labels <- r0s %>%
     dplyr::group_by(location) %>%
     dplyr::summarise(mean=mean(r0)) %>%
-    dplyr::arrange(mean) %>%
+    dplyr::arrange(if(sort==TRUE){mean}else{location}) %>%
     dplyr::mutate(label = glue::glue("Location: {location}, R0: {round(mean,2)}"))
 
   # get ordering of locations by R0

--- a/man/hom_plot_incidence_by_location.Rd
+++ b/man/hom_plot_incidence_by_location.Rd
@@ -9,7 +9,8 @@ hom_plot_incidence_by_location(
   posts = NULL,
   outbreak_cases = NULL,
   end_time = 60,
-  location_labels = NULL
+  location_labels = NULL,
+  sort = TRUE
 )
 }
 \arguments{
@@ -23,6 +24,8 @@ hom_plot_incidence_by_location(
 
 \item{location_labels}{tibble with columns `site` and `location`. Will be used to
 relabel numeric location to values in `site` column}
+
+\item{sort}{TRUE/FALSE. If TRUE (default), locations will be ordered by mean R0}
 }
 \value{
 list containing:

--- a/man/hom_plot_r0_by_location.Rd
+++ b/man/hom_plot_r0_by_location.Rd
@@ -4,12 +4,14 @@
 \alias{hom_plot_r0_by_location}
 \title{Plot r0 by location as extracted from hierarchical outbreak model.}
 \usage{
-hom_plot_r0_by_location(extracted_posts = NULL, posts = NULL)
+hom_plot_r0_by_location(extracted_posts = NULL, posts = NULL, sort = TRUE)
 }
 \arguments{
 \item{extracted_posts}{object returned by hom_extract_posterior_draws}
 
 \item{posts}{Object after calling extract of stan model object of hierarchical model}
+
+\item{sort}{TRUE/FALSE. If TRUE (default), locations will be ordered by mean R0}
 }
 \value{
 list containing:
@@ -21,7 +23,7 @@ If extracted_posts is NULL then posts object is used to first extract the R0
 and incidence draws from posterior (note this will take longer)
 }
 \note{
-Naming convention throughout is snake case with prefix "hom_" to denote Hierarcical Outbreak Model
+Naming convention throughout is snake case with prefix "hom_" to denote Hierarchical Outbreak Model
 }
 \examples{
 \dontrun{

--- a/man/hom_plot_zeta_by_location.Rd
+++ b/man/hom_plot_zeta_by_location.Rd
@@ -4,12 +4,14 @@
 \alias{hom_plot_zeta_by_location}
 \title{Plot zeta by location as extracted from hierarchical outbreak model.}
 \usage{
-hom_plot_zeta_by_location(extracted_posts = NULL, posts = NULL)
+hom_plot_zeta_by_location(extracted_posts = NULL, posts = NULL, sort = TRUE)
 }
 \arguments{
 \item{extracted_posts}{object returned by hom_extract_posterior_draws}
 
 \item{posts}{Object after calling extract of stan model object of hierarchical model}
+
+\item{sort}{TRUE/FALSE. If TRUE (default), locations will be ordered by mean R0}
 }
 \value{
 list containing:

--- a/vignettes/BC_outbreak_data_fitting.Rmd
+++ b/vignettes/BC_outbreak_data_fitting.Rmd
@@ -199,7 +199,7 @@ hom_plot_critical_times_by_location(posts,
 
 ```
 
-# Hierarcichal intervention model
+# Hierarchichal intervention model
 
 Fit model including estimating intervention by each location in a hierarchical
 design,
@@ -227,7 +227,7 @@ posts <- rstan::extract(bc_fit_zeta$model)
 extracted_posts <- hom_extract_posterior_draws(posts,
                                   location_labels = location_labels) 
 
-result <- hom_plot_r0_by_location(extracted_posts=extracted_posts)
+result <- hom_plot_r0_by_location(extracted_posts=extracted_posts, sort=FALSE)
 
 # plot results
 show(result$plot + labs(y=TeX("$R_{0,k}$")))
@@ -244,7 +244,7 @@ result$table %>%
 
 ```{r fig.hieght=12,fig.width=8}
 
-result <- hom_plot_zeta_by_location(extracted_posts=extracted_posts)
+result <- hom_plot_zeta_by_location(extracted_posts=extracted_posts,sort=FALSE)
 
 # plot results
 show(result$plot)
@@ -261,8 +261,8 @@ result$table %>%
 ```{r, fig.height=12,fig.width=8}
 result <- hom_plot_incidence_by_location(extracted_posts=extracted_posts,
                                          outbreak_cases = outbreak_cases,
-                                         location_labels = location_labels
-                                         )
+                                         location_labels = location_labels,
+                                         sort=FALSE)
 # plot results
 result$plot
 


### PR DESCRIPTION
- Added sort=TRUE/FALSE input to several plotting functions, to allow ordering by increasing R0 or by location name
- Set sort=FALSE for multi-level zeta figures in package vignette, so all plots are ordered the same (alphabetically)